### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ NOTE: it's not run on `down`. If you have any reason to do it please feel free t
 
 ## Testing migrations
 
-To keep your migrations working don't forget to write tests for them. It's preferably to put the tests for migrations into `spec/db/migrations` folder, but actually it's up to you. Possible `RSpec` test (`spec/db/migratios/create_user.rb`) for the migration looks like this:
+To keep your migrations working don't forget to write tests for them. It's preferably to put the tests for migrations into `spec/db/migrations` folder, but actually it's up to you. Possible `RSpec` test (`spec/db/migrations/create_user.rb`) for the migration looks like this:
 
 ```ruby
 require 'spec_helper'


### PR DESCRIPTION
fix typo: `spec/db/migratios/create_user.rb` ---> `spec/db/migrations/create_user.rb`