### PR TITLE
Add ability to rollback data on down direction

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,15 @@ class CreateUsers < ActiveRecord::Migration
   def data
     User.create!(name: 'Andrey', email: 'ka8725@gmail.com')
   end
+
+  def rollback
+    User.find_by(name: 'Andrey', email: 'ka8725@gmail.com').destroy
+  end
 end
 ```
 
 That's it. Now when you run migrations with the `rake db:migrate` command the `data` method will be run on `up`.
-
-NOTE: it's not run on `down`. If you have any reason to do it please feel free to make a pull request.
+When you rollback migrations with the `rake db:rollback` command the `rollback` method will be run on `down`.
 
 ## Testing migrations
 
@@ -61,6 +64,12 @@ describe CreateUsers do
   describe '#data' do
     it 'works' do
       expect { described_class.new.data }.to_not raise_exception
+    end
+  end
+
+  describe '#rollback' do
+    it 'works' do
+      expect { described_class.new.rollback }.to_not raise_exception
     end
   end
 end

--- a/lib/migration_data/active_record/migration.rb
+++ b/lib/migration_data/active_record/migration.rb
@@ -6,6 +6,7 @@ module MigrationData
           def exec_migration_with_data(conn, direction)
             origin_exec_migration(conn, direction)
             data if direction == :up && respond_to?(:data)
+            rollback if direction == :down && respond_to?(:rollback)
           end
 
           alias origin_exec_migration exec_migration

--- a/test/migration_test.rb
+++ b/test/migration_test.rb
@@ -1,10 +1,14 @@
 require 'test_helper'
 
 class MyMigration < ActiveRecord::Migration
-  attr_reader :migrated_data
+  attr_reader :migrated_data, :rolled_back_data
 
   def data
     @migrated_data = true
+  end
+
+  def rollback
+    @rolled_back_data = true
   end
 end
 
@@ -22,6 +26,16 @@ describe MyMigration do
     it "doesn't run #data on down direction" do
       @migration.migrate(:down)
       assert_nil @migration.migrated_data
+    end
+
+    it 'runs #rollback on down direction' do
+      @migration.migrate(:down)
+      assert @migration.rolled_back_data
+    end
+
+    it "doesn't run #rollback on up direction" do
+      @migration.migrate(:up)
+      assert_nil @migration.rolled_back_data
     end
   end
 end


### PR DESCRIPTION
* Update `test/migration_test.rb` to test `#rollback` method is called
* Add call to rollback method in `MigrationData::ActiveRecord::Migration` if direction is `:down` and migration responds to `#rollback`
* Update README.md to reflect new functionality