### PR TITLE
Rake 1.6 on gemspec

### DIFF
--- a/migration_data.gemspec
+++ b/migration_data.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency 'bundler', '~> 1.5'
-  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rake', '~> 1.6'
   spec.add_development_dependency 'sqlite3'
   spec.add_dependency 'rails', '>= 4.0.0.rc1'
 end


### PR DESCRIPTION
Rake 2.0 requires ruby 2.2 

https://github.com/rack/rack/blob/2.0.0.alpha/rack.gemspec#L29