### PR TITLE
skip data up down methods in test env

### DIFF
--- a/lib/migration_data/active_record/migration.rb
+++ b/lib/migration_data/active_record/migration.rb
@@ -5,8 +5,10 @@ module MigrationData
         base.class_eval do
           def exec_migration_with_data(conn, direction)
             origin_exec_migration(conn, direction)
-            data if direction == :up && respond_to?(:data)
-            rollback if direction == :down && respond_to?(:rollback)
+            unless ENV['RAILS_ENV'] == 'test'
+              data if direction == :up && respond_to?(:data)
+              rollback if direction == :down && respond_to?(:rollback)
+            end
           end
 
           alias origin_exec_migration exec_migration

--- a/test/migration_test.rb
+++ b/test/migration_test.rb
@@ -17,25 +17,28 @@ describe MyMigration do
     @migration = MyMigration.new
   end
 
-  describe '#migrate' do
-    it 'runs #data on up direction' do
-      @migration.migrate(:up)
-      assert @migration.migrated_data
-    end
+  unless ENV['RAILS_ENV'] == 'test'
+    describe '#migrate' do
+      it 'runs #data on up direction' do
+        @migration.migrate(:up)
+        assert @migration.migrated_data
+      end
 
-    it "doesn't run #data on down direction" do
-      @migration.migrate(:down)
-      assert_nil @migration.migrated_data
-    end
+      it "doesn't run #data on down direction" do
+        @migration.migrate(:down)
+        assert_nil @migration.migrated_data
+      end
 
-    it 'runs #rollback on down direction' do
-      @migration.migrate(:down)
-      assert @migration.rolled_back_data
-    end
+      it 'runs #rollback on down direction' do
+        @migration.migrate(:down)
+        assert @migration.rolled_back_data
+      end
 
-    it "doesn't run #rollback on up direction" do
-      @migration.migrate(:up)
-      assert_nil @migration.rolled_back_data
+      it "doesn't run #rollback on up direction" do
+        @migration.migrate(:up)
+        assert_nil @migration.rolled_back_data
+      end
     end
   end
+  
 end


### PR DESCRIPTION
We often find ourself having to add hacks into the data method to bypass them when running migrations when `RAILS_ENV=test`.  We'd like to skip all data methods for test environment.  What do you think?