### PR TITLE
Clear activerecord schema cache after migration

### DIFF
--- a/lib/migration_data/active_record/migration.rb
+++ b/lib/migration_data/active_record/migration.rb
@@ -15,6 +15,7 @@ module MigrationData
         base.class_eval do
           def exec_migration_with_data(conn, direction)
             origin_exec_migration(conn, direction)
+            ::ActiveRecord::Base.connection.schema_cache.clear!
             data if direction == :up && respond_to?(:data)
             rollback if direction == :down && respond_to?(:rollback)
           end


### PR DESCRIPTION
If migration added new column and data uses this column,
active record generated queries might fail, because it's
not included in cached fields list don't know it