### PR TITLE
Add ability to skip data migrations optionally

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,14 @@ end
 
 The helper to load migrations `require_migration` is defined in the `migration_data/testing`. So you should to require it to have access to this convinient require extension.
 
+## Skipping data migration in test environment  
+
+On performing migrations in test environment, a data migration might try to add same data that is already added by seeds. In that case the migration fails with a duplication error.
+
+In this case your migrations might fall with duplication error.
+
+Use `MigrationData.config.skip = true` to skip data migrations execution. It can be helpful for the test environment, for example.
+
 ## Contributing
 
 1. Fork it ( http://github.com/ka8725/migration_data/fork )

--- a/lib/migration_data.rb
+++ b/lib/migration_data.rb
@@ -1,6 +1,7 @@
 require 'active_record'
 require 'migration_data/version'
 require 'migration_data/active_record/migration'
+require 'migration_data/config'
 
 require 'rake'
 import File.join(File.dirname(__FILE__), 'tasks', 'db.rake')

--- a/lib/migration_data/active_record/migration.rb
+++ b/lib/migration_data/active_record/migration.rb
@@ -15,6 +15,8 @@ module MigrationData
         base.class_eval do
           def exec_migration_with_data(conn, direction)
             origin_exec_migration(conn, direction)
+            ::ActiveRecord::Base.connection.schema_cache.clear!
+            return if MigrationData.config.skip_data_on_test
             data if direction == :up && respond_to?(:data)
             rollback if direction == :down && respond_to?(:rollback)
           end

--- a/lib/migration_data/config.rb
+++ b/lib/migration_data/config.rb
@@ -1,0 +1,6 @@
+module MigrationData
+  @config = Struct.new(:skip_data_on_test).new(false)
+  def self.config
+    @config
+  end
+end

--- a/test/migration_test.rb
+++ b/test/migration_test.rb
@@ -38,4 +38,24 @@ describe MyMigration do
       assert_nil @migration.rolled_back_data
     end
   end
+
+  describe "#migrate with Rails.env = test and skip_data_on_test = true" do
+    before do
+      @old_skip, MigrationData.config.skip_data_on_test = MigrationData.config.skip_data_on_test, true
+    end
+
+    after do
+      MigrationData.config.skip_data_on_test = @old_skip
+    end
+
+    it "doesn't runs #data" do
+      @migration.migrate(:up)
+      refute @migration.migrated_data
+    end
+
+    it "doesn't runs #rollback" do
+      @migration.migrate(:down)
+      refute @migration.rolled_back_data
+    end
+  end
 end


### PR DESCRIPTION
Add ability to skip data migration run optionally.

If data migrations should be skipped for some environment, put these lines in an initializer, e.g. `config/initializers/migration_data.rb`:

```ruby
if Rails.env.test?
  MigrationData.config.skip = true
end
```